### PR TITLE
added config folder in wikitongues/wikitongues for spider config file

### DIFF
--- a/wikitongues/wikitongues/config/__init__.py
+++ b/wikitongues/wikitongues/config/__init__.py
@@ -1,0 +1,3 @@
+# This package will contain the config files for the language indexing details
+#
+

--- a/wikitongues/wikitongues/config/__init__.py
+++ b/wikitongues/wikitongues/config/__init__.py
@@ -1,3 +1,2 @@
 # This package will contain the config files for the language indexing details
 #
-

--- a/wikitongues/wikitongues/config/indexing.cfg
+++ b/wikitongues/wikitongues/config/indexing.cfg
@@ -1,0 +1,43 @@
+#formatting guidlines for this config file: 
+#  All sections, keys, or values with multiple words will utilize snake case. The only exceptions are the spider class names.
+#  Only language names will be capitalized in the keys. Values may be capitalized depending on what the URI components need 
+
+#This config begins with the 'sites' section. Each key in this section will have a value the same as the key, but with '_site' appended
+# for each key's value, there should be a section by that same name
+[sites]
+wikipedia : wikipedia_site
+#fake : fake_site
+
+#each web_site should have the keys root and language pages. The key, root, has the base url for the site.
+# the key, site_language_pages will be the name of a related section. 
+[wikipedia_site]
+root : https://en.wikipedia.org/wiki/
+site_language_pages : wikipedia_language_pages
+
+#the web_pages sections will have a key for every language that the site can be scraped for. The key will be the language's name. 
+# The value for each key will be the URI component to be appended to the site's root to be able to reach that page
+[wikipedia_language_pages]
+Sakha : Yakut_language
+Jèrriais : J%%C3%%A8rriais
+Quechua : Quechuan_languages
+Nyungar : Nyungar_language
+Xhosa : Xhosa_language
+Sioux : Sioux_language
+
+#These are the language codes. Yay! Every language that scraped should be noted here in this section. The pages section of each site will
+# leverage this section.
+[language_codes]
+English : eng
+Sakha : sah
+Jèrriais : nrf
+Quechua : qwe
+Nyungar : nys
+Xhosa : xho
+Sioux : dak
+
+#the spiders section will have a key for every spider, the key should be the name of the site, and the value should be the same
+# buth with '_spider' appended. This follows the naming scheme of the spider's python file.
+[spiders]
+wikipedia : WikipediaSpider
+fake : fake_spider
+

--- a/wikitongues/wikitongues/language-indexing
+++ b/wikitongues/wikitongues/language-indexing
@@ -2,19 +2,11 @@
 
 import scrapy
 from scrapy.crawler import CrawlerProcess
-
-from spiders.wikipedia_spider import WikipediaSpider
+import configparser
+import os, sys, pkgutil, importlib
 
 from language import Language
 
-languages = [
-    Language('sah', 'Sakha', 'https://en.wikipedia.org/wiki/Yakut_language'),
-    Language('nrf', 'Jèrriais', 'https://en.wikipedia.org/wiki/J%C3%A8rriais'),
-    Language('qwe', 'Quechua', 'https://en.wikipedia.org/wiki/Quechuan_languages'),
-    Language('nys', 'Nyungar', 'https://en.wikipedia.org/wiki/Nyungar_language'),
-    Language('xho', 'Xhosa', 'https://en.wikipedia.org/wiki/Xhosa_language'),
-    Language('dak', 'Sioux', 'https://en.wikipedia.org/wiki/Sioux_language')
-]
 
 process = CrawlerProcess(
     settings={
@@ -26,6 +18,43 @@ process = CrawlerProcess(
     }
 )
 
-process.crawl(WikipediaSpider, languages)
+def process_site(site_tuple):
+    root_url = config[site_tuple[1]]['root']
+    site_language_pages = config[site_tuple[1]]['site_language_pages']
+    site_language_pages_items = config.items(site_language_pages)
+    site_languages = [] 
+    for site_lang_page_item in site_language_pages_items:
+        site_languages.append(Language(config['language_codes'][site_lang_page_item[0]], site_lang_page_item[0], config[site_tuple[1]]['root'] + site_lang_page_item[1]))
+    
+    spiders_dir_tree = os.listdir('wikitongues/wikitongues/spiders')
 
-process.start()
+    for t in spiders_dir_tree:
+        if t.__contains__(site_tuple[0]):
+            spiderClass = getattr(importlib.import_module('spiders.' + t[:-3]), config['spiders'][site_tuple[0]])
+            process.crawl(spiderClass, site_languages)
+            process.start()
+            
+
+    
+config = configparser.ConfigParser()
+config.read(os.path.join(os.path.dirname(__file__), 'config', 'indexing.cfg'))
+sites = config.items('sites')
+start_all_crawls = input('Do you wish to crawl all spiders? (Y/N) ')
+#start_all_crawls = 'y'
+if start_all_crawls.lower() == 'n':
+    site_to_crawl = input('Which site would you like to crawl? ')
+    for site in sites:
+        if site_to_crawl == site[0]:
+            process_site(site_to_crawl)
+            break
+    print('Invalid input: could not find a site that matched your input')
+        
+elif start_all_crawls.lower() == 'y':
+    for site in sites:
+        process_site(site)
+        print(site[1])
+
+else:
+    print('invalid input')
+
+    


### PR DESCRIPTION
Added a config file for spiders.

The config file lays out a workflow for people to add config sections for their respective spiders. The config file has comments explaining the logic of the different sections and identifies for the developer what sections to modify and what new sections to create to add more spiders.

The idea driving the config file design is that no python code will need to be modified if more spiders need to be added. As long as the spider class is added in the same way as the wikipedia spider (in the path spiders/sitename_spider), and the appropriate entries are made to the config file, then the application should be able to process the new spider and the new sites should be scraped. 