### PR TITLE
User config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
 env
 __pycache__
 *.jl
-.vscode/
-.idea/
-*/wikitongues-language-indexingo.cfg
 venv/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 .vscode/
 .idea/
 */wikitongues-language-indexingo.cfg
+venv/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 *.jl
 .vscode/
 .idea/
+*/wikitongues-language-indexingo.cfg

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 env
 __pycache__
 *.jl
+.vscode/
+.idea/

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/Language-Indexing.iml
+++ b/.idea/Language-Indexing.iml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/wikitongues/wikitongues" isTestSource="false" />
+      <excludeFolder url="file://$MODULE_DIR$/venv" />
+    </content>
+    <orderEntry type="jdk" jdkName="Python 3.7 (Language-Indexing)" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="GOOGLE" />
+    <option name="myDocStringFormat" value="Google" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.7 (Language-Indexing)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/Language-Indexing.iml" filepath="$PROJECT_DIR$/.idea/Language-Indexing.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-ignore = E265
+ignore = E265,W503
 # Exclude files that are mainly Scrapy boilerplate
 exclude =
     env

--- a/wikitongues/wikitongues/config/indexing.cfg
+++ b/wikitongues/wikitongues/config/indexing.cfg
@@ -26,6 +26,6 @@ wikipedia : WikipediaSpider
 fake : fake_spider
 
 [local_config_path]
-windows path : '\\Wikitongues\\Indexing-Project\\'
-linux path : '/Wikitongues/Indexing-Project/'
-config file name : 'wikitongues-language-indexingo.cfg'
+windows path : \Wikitongues\Indexing-Project\
+linux path : /Wikitongues/Indexing-Project/
+config file name : wikitongues-language-indexing.cfg

--- a/wikitongues/wikitongues/config/indexing.cfg
+++ b/wikitongues/wikitongues/config/indexing.cfg
@@ -25,7 +25,5 @@ Sakha : sah
 wikipedia : WikipediaSpider
 fake : fake_spider
 
-[local_config_path]
-windows path : \Wikitongues\Indexing-Project\
-linux path : /Wikitongues/Indexing-Project/
-config file name : wikitongues-language-indexing.cfg
+[local_config_file]
+local config file : wikitongues-language-indexing.cfg

--- a/wikitongues/wikitongues/config/indexing.cfg
+++ b/wikitongues/wikitongues/config/indexing.cfg
@@ -25,3 +25,7 @@ Sakha : sah
 wikipedia : WikipediaSpider
 fake : fake_spider
 
+[local_config_path]
+windows path : '\\Wikitongues\\Indexing-Project\\'
+linux path : '/Wikitongues/Indexing-Project/'
+config file name : 'wikitongues-language-indexingo.cfg'

--- a/wikitongues/wikitongues/config/load_configs.py
+++ b/wikitongues/wikitongues/config/load_configs.py
@@ -22,7 +22,7 @@ def load_configs():
         env += local_config_paths[1][1]
     else:
         raise Exception("This program is intended only for Mac,"
-                      + "Linux, or Windows machines.")
+                                            + "Linux, or Windows machines.")
 
     try:
         user_config_file = open(env + local_config_paths[2][1])

--- a/wikitongues/wikitongues/config/load_configs.py
+++ b/wikitongues/wikitongues/config/load_configs.py
@@ -10,12 +10,12 @@ def load_configs():
 
     default_config = configparser.ConfigParser()
     current_dir = os.path.dirname(__file__)
-    default_config.read_file(open(os.path.join(current_dir,"indexing.cfg")))
+    default_config.read_file(open(os.path.join(current_dir, "indexing.cfg")))
     local_config_paths = default_config.items("local_config_path")
 
     user_config = configparser.ConfigParser()
 
-    if platform == "windows":
+    if platform == "windows" or platform == "win32":
         env = os.getenv("APPDATA")
         env += local_config_paths[0][1]
     elif platform == "linux" or platform == "linux2" or platform == "darwin":

--- a/wikitongues/wikitongues/config/load_configs.py
+++ b/wikitongues/wikitongues/config/load_configs.py
@@ -5,14 +5,13 @@ import os
 
 def load_configs():
     print("loading config file")
-    #default_config_text = pkg_resources.read_text(config_pkg, 'indexing.cfg')
+
     default_config = configparser.ConfigParser()
-    default_config.read('indexing.cfg')
+    default_config.read_file(open('config/indexing.cfg'))
     local_config_paths = default_config.items('local_config_path')
 
     user_config = configparser.ConfigParser()
 
-    # We can change these hard-coded paths out for constants in the settings file
     if platform == "win32":
         env = os.getenv('APPDATA')
         env += local_config_paths[0][1]
@@ -20,24 +19,23 @@ def load_configs():
         env = os.getenv('HOME')
         env += local_config_paths[1][1]
 
+
+
     try:
         user_config_file = open(env + local_config_paths[2][1])
         user_config.read_file(user_config_file)
+        user_config_file.close()
         pass
     except FileNotFoundError:
         print("Error: User config file not found at path " + env + local_config_paths[2][1])
         sys.exit(1)
         pass
-    finally:
-        user_config_file.close()
-    # user_config.read_file(env + 'wikitongues-language-indexing.cfg')
-    default_sites = default_config.items('sites')
-    user_sites = user_config.items('sites')
-    if user_sites.length <= 0: # != "replace_me":
+
+    if len(user_config.items('sites')) > 0:
         # override sites configuration
         print("Using user configuration")
-        return user_sites
+        return user_config
     else:
         # nothing overridden. return the default config settings
         print("Using default configuration")
-        return default_sites
+        return default_config

--- a/wikitongues/wikitongues/config/load_configs.py
+++ b/wikitongues/wikitongues/config/load_configs.py
@@ -21,8 +21,8 @@ def load_configs():
         env = os.getenv('HOME')
         env += local_config_paths[1][1]
     else:
-        raise Exception("This program is intended only for Mac," 
-             + "Linux, or Windows machines.")
+        raise Exception("This program is intended only for Mac,"
+                + "Linux, or Windows machines.")
 
     try:
         user_config_file = open(env + local_config_paths[2][1])

--- a/wikitongues/wikitongues/config/load_configs.py
+++ b/wikitongues/wikitongues/config/load_configs.py
@@ -3,7 +3,9 @@ from sys import platform
 import configparser
 import os
 
+
 def load_configs():
+
     print("loading config file")
 
     default_config = configparser.ConfigParser()
@@ -19,15 +21,14 @@ def load_configs():
         env = os.getenv('HOME')
         env += local_config_paths[1][1]
 
-
-
     try:
         user_config_file = open(env + local_config_paths[2][1])
         user_config.read_file(user_config_file)
         user_config_file.close()
         pass
     except FileNotFoundError:
-        print("Error: User config file not found at path " + env + local_config_paths[2][1])
+        print("Error: User config file not found at path " +
+              env + local_config_paths[2][1])
         sys.exit(1)
         pass
 

--- a/wikitongues/wikitongues/config/load_configs.py
+++ b/wikitongues/wikitongues/config/load_configs.py
@@ -1,0 +1,39 @@
+import sys
+from sys import platform
+import configparser
+import os
+
+def load_configs():
+    print("loading")
+    #default_config_text = pkg_resources.read_text(config_pkg, 'indexing.cfg')
+    default_config = configparser.ConfigParser()
+    default_config.read('indexing.cfg')
+
+    user_config = configparser.ConfigParser()
+
+    if platform == "win32":
+        env = os.getenv('APPDATA')
+        env += '\\Wikitongues\\Indexing-Project\\'
+    elif (platform == "linux" or platform == "linux2"):
+        env = os.getenv('HOME')
+        env += '/Wikitongues/Indexing-Project/'
+
+    try:
+        user_config_file = open(env + 'wikitongues-language-indexingo.cfg')
+        user_config.read_file(user_config_file)
+        pass
+    except FileNotFoundError:
+        print("Error: User config file not found")
+        sys.exit(1)
+        pass
+    finally:
+        user_config_file.close()
+    # user_config.read_file(env + 'wikitongues-language-indexing.cfg')
+    defualt_sites = default_config.items('sites')
+    user_sites = user_config.items('sites')
+    if user_sites[0][1] != "replace_me":
+        # override sites configuration
+        return user_sites
+    else:
+        # nothing overridden. return the default config settings
+        return defualt_sites

--- a/wikitongues/wikitongues/config/load_configs.py
+++ b/wikitongues/wikitongues/config/load_configs.py
@@ -22,7 +22,7 @@ def load_configs():
         env += local_config_paths[1][1]
     else:
         raise Exception("This program is intended only for Mac,"
-                + "Linux, or Windows machines.")
+                      + "Linux, or Windows machines.")
 
     try:
         user_config_file = open(env + local_config_paths[2][1])

--- a/wikitongues/wikitongues/config/load_configs.py
+++ b/wikitongues/wikitongues/config/load_configs.py
@@ -22,7 +22,7 @@ def load_configs():
         env += local_config_paths[1][1]
     else:
         raise Exception("This program is intended only for Mac,"
-                                            + "Linux, or Windows machines.")
+                        + "Linux, or Windows machines.")
 
     try:
         user_config_file = open(env + local_config_paths[2][1])

--- a/wikitongues/wikitongues/config/load_configs.py
+++ b/wikitongues/wikitongues/config/load_configs.py
@@ -9,11 +9,11 @@ def load_configs():
     print("loading config file")
 
     default_config = configparser.ConfigParser()
-    default_config.read_file(open('config/indexing.cfg'))
+    default_config.read_file(open('indexing.cfg'))
     local_config_paths = default_config.items('local_config_path')
 
     user_config = configparser.ConfigParser()
-    
+
     if platform == "Windows":
         env = os.getenv('APPDATA')
         env += local_config_paths[0][1]
@@ -21,7 +21,8 @@ def load_configs():
         env = os.getenv('HOME')
         env += local_config_paths[1][1]
     else:
-        raise Exception('This program is intended only for Mac, Linux, or Windows machines.')
+        raise Exception("This program is intended only for Mac," 
+             + "Linux, or Windows machines.")
 
     try:
         user_config_file = open(env + local_config_paths[2][1])

--- a/wikitongues/wikitongues/config/load_configs.py
+++ b/wikitongues/wikitongues/config/load_configs.py
@@ -13,13 +13,15 @@ def load_configs():
     local_config_paths = default_config.items('local_config_path')
 
     user_config = configparser.ConfigParser()
-
-    if platform == "win32":
+    
+    if platform == "Windows":
         env = os.getenv('APPDATA')
         env += local_config_paths[0][1]
-    elif platform == "linux" or platform == "linux2":
+    elif platform == "Linux" or platform == "linux2" or platform == "Darwin":
         env = os.getenv('HOME')
         env += local_config_paths[1][1]
+    else:
+        raise Exception('This program is intended only for Mac, Linux, or Windows machines.')
 
     try:
         user_config_file = open(env + local_config_paths[2][1])

--- a/wikitongues/wikitongues/config/load_configs.py
+++ b/wikitongues/wikitongues/config/load_configs.py
@@ -11,29 +11,27 @@ def load_configs():
     default_config = configparser.ConfigParser()
     current_dir = os.path.dirname(__file__)
     default_config.read_file(open(os.path.join(current_dir, "indexing.cfg")))
-    local_config_paths = default_config.items("local_config_path")
+    local_config_file = default_config.items("local_config_file")
 
     user_config = configparser.ConfigParser()
 
     if platform == "windows" or platform == "win32":
         env = os.getenv("APPDATA")
-        env += local_config_paths[0][1]
     elif platform == "linux" or platform == "linux2" or platform == "darwin":
         env = os.getenv("HOME")
-        env += local_config_paths[1][1]
     else:
         raise Exception("This program is intended only for Mac,"
                         + "Linux, or Windows machines.")
 
     try:
-        user_config_file = open(env + local_config_paths[2][1])
+        user_config_file = open(env + local_config_file[0][1])
         user_config.read_file(user_config_file)
         user_config_file.close()
         pass
     except FileNotFoundError:
         print("Error: User config file not found at path "
               + env
-              + local_config_paths[2][1])
+              + local_config_file[0][1])
         sys.exit(1)
         pass
 

--- a/wikitongues/wikitongues/config/load_configs.py
+++ b/wikitongues/wikitongues/config/load_configs.py
@@ -28,7 +28,8 @@ def load_configs():
         pass
     except FileNotFoundError:
         print("Error: User config file not found at path "
-              + env + local_config_paths[2][1])
+              + env
+              + local_config_paths[2][1])
         sys.exit(1)
         pass
 

--- a/wikitongues/wikitongues/config/load_configs.py
+++ b/wikitongues/wikitongues/config/load_configs.py
@@ -4,36 +4,40 @@ import configparser
 import os
 
 def load_configs():
-    print("loading")
+    print("loading config file")
     #default_config_text = pkg_resources.read_text(config_pkg, 'indexing.cfg')
     default_config = configparser.ConfigParser()
     default_config.read('indexing.cfg')
+    local_config_paths = default_config.items('local_config_path')
 
     user_config = configparser.ConfigParser()
 
+    # We can change these hard-coded paths out for constants in the settings file
     if platform == "win32":
         env = os.getenv('APPDATA')
-        env += '\\Wikitongues\\Indexing-Project\\'
-    elif (platform == "linux" or platform == "linux2"):
+        env += local_config_paths[0][1]
+    elif platform == "linux" or platform == "linux2":
         env = os.getenv('HOME')
-        env += '/Wikitongues/Indexing-Project/'
+        env += local_config_paths[1][1]
 
     try:
-        user_config_file = open(env + 'wikitongues-language-indexingo.cfg')
+        user_config_file = open(env + local_config_paths[2][1])
         user_config.read_file(user_config_file)
         pass
     except FileNotFoundError:
-        print("Error: User config file not found")
+        print("Error: User config file not found at path " + env + local_config_paths[2][1])
         sys.exit(1)
         pass
     finally:
         user_config_file.close()
     # user_config.read_file(env + 'wikitongues-language-indexing.cfg')
-    defualt_sites = default_config.items('sites')
+    default_sites = default_config.items('sites')
     user_sites = user_config.items('sites')
-    if user_sites[0][1] != "replace_me":
+    if user_sites.length <= 0: # != "replace_me":
         # override sites configuration
+        print("Using user configuration")
         return user_sites
     else:
         # nothing overridden. return the default config settings
-        return defualt_sites
+        print("Using default configuration")
+        return default_sites

--- a/wikitongues/wikitongues/config/load_configs.py
+++ b/wikitongues/wikitongues/config/load_configs.py
@@ -27,8 +27,8 @@ def load_configs():
         user_config_file.close()
         pass
     except FileNotFoundError:
-        print("Error: User config file not found at path " +
-              env + local_config_paths[2][1])
+        print("Error: User config file not found at path "
+              + env + local_config_paths[2][1])
         sys.exit(1)
         pass
 

--- a/wikitongues/wikitongues/config/load_configs.py
+++ b/wikitongues/wikitongues/config/load_configs.py
@@ -9,16 +9,17 @@ def load_configs():
     print("loading config file")
 
     default_config = configparser.ConfigParser()
-    default_config.read_file(open('indexing.cfg'))
-    local_config_paths = default_config.items('local_config_path')
+    current_dir = os.path.dirname(__file__)
+    default_config.read_file(open(os.path.join(current_dir,"indexing.cfg")))
+    local_config_paths = default_config.items("local_config_path")
 
     user_config = configparser.ConfigParser()
 
-    if platform == "Windows":
-        env = os.getenv('APPDATA')
+    if platform == "windows":
+        env = os.getenv("APPDATA")
         env += local_config_paths[0][1]
-    elif platform == "Linux" or platform == "linux2" or platform == "Darwin":
-        env = os.getenv('HOME')
+    elif platform == "linux" or platform == "linux2" or platform == "darwin":
+        env = os.getenv("HOME")
         env += local_config_paths[1][1]
     else:
         raise Exception("This program is intended only for Mac,"
@@ -36,7 +37,7 @@ def load_configs():
         sys.exit(1)
         pass
 
-    if len(user_config.items('sites')) > 0:
+    if len(user_config.items("sites")) > 0:
         # override sites configuration
         print("Using user configuration")
         return user_config

--- a/wikitongues/wikitongues/language_indexing.py
+++ b/wikitongues/wikitongues/language_indexing.py
@@ -73,6 +73,7 @@ if start_all_crawls.lower() == 'n':
             process_site(site_to_crawl)
             break
     print('Invalid input: could not find a site that matched your input')
+    sys.exit(1)
 
 elif start_all_crawls.lower() == 'y':
     for site in sites:
@@ -81,3 +82,4 @@ elif start_all_crawls.lower() == 'y':
 
 else:
     print('invalid input')
+    sys.exit(1)

--- a/wikitongues/wikitongues/language_indexing.py
+++ b/wikitongues/wikitongues/language_indexing.py
@@ -1,24 +1,20 @@
 #!/usr/bin/env python
 
 # Entry point for the program, invoked from the console
+import sys
 
 from scrapy.crawler import CrawlerProcess
-import configparser
 import os
 import importlib
 
-try:
-    import importlib.resources as pkg_resources
-except ImportError:
-    # Try backported to PY<37 `importlib_resources`.
-    import importlib_resources as pkg_resources  # noqa: F401
-
+from config import load_configs
 from spiders.wikipedia_spider import WikipediaSpiderInput  # noqa: E501
 from data_store.airtable.airtable_language_data_store_factory import AirtableLanguageDataStoreFactory  # noqa: E501
 from data_store.airtable.airtable_connection_info import AirtableConnectionInfo
 from data_store.airtable.airtable_table_info import AirtableTableInfo
 
 import config as config_pkg
+import this as wikitongues_pkg
 
 # Info required to connect to Airtable
 # TODO read from config file
@@ -65,12 +61,11 @@ def process_site(site_tuple):
             process.start()
 
 
-config_text = pkg_resources.read_text(config_pkg, 'indexing.cfg')
-config = configparser.ConfigParser()
-config.read_string(config_text)
+config = load_configs()
 sites = config.items('sites')
+
 start_all_crawls = input('Do you wish to crawl all spiders? (Y/N) ')
-#start_all_crawls = 'y'
+# start_all_crawls = 'y'
 if start_all_crawls.lower() == 'n':
     site_to_crawl = input('Which site would you like to crawl? ')
     for site in sites:

--- a/wikitongues/wikitongues/language_indexing.py
+++ b/wikitongues/wikitongues/language_indexing.py
@@ -7,14 +7,11 @@ from scrapy.crawler import CrawlerProcess
 import os
 import importlib
 
-from config import load_configs
+from config.load_configs import load_configs
 from spiders.wikipedia_spider import WikipediaSpiderInput  # noqa: E501
 from data_store.airtable.airtable_language_data_store_factory import AirtableLanguageDataStoreFactory  # noqa: E501
 from data_store.airtable.airtable_connection_info import AirtableConnectionInfo
 from data_store.airtable.airtable_table_info import AirtableTableInfo
-
-import config as config_pkg
-import this as wikitongues_pkg
 
 # Info required to connect to Airtable
 # TODO read from config file
@@ -65,7 +62,7 @@ config = load_configs()
 sites = config.items('sites')
 
 start_all_crawls = input('Do you wish to crawl all spiders? (Y/N) ')
-# start_all_crawls = 'y'
+
 if start_all_crawls.lower() == 'n':
     site_to_crawl = input('Which site would you like to crawl? ')
     for site in sites:

--- a/wikitongues/wikitongues/language_indexing.py
+++ b/wikitongues/wikitongues/language_indexing.py
@@ -6,7 +6,6 @@ import sys
 from scrapy.crawler import CrawlerProcess
 import os
 import importlib
-
 from config.load_configs import load_configs
 from spiders.wikipedia_spider import WikipediaSpiderInput  # noqa: E501
 from data_store.airtable.airtable_language_data_store_factory import AirtableLanguageDataStoreFactory  # noqa: E501


### PR DESCRIPTION
Reads from c:\users\username\AppData\Roaming\Wikitongues\Indexing-Project\wikitongues-language-indexing.cfg for windows or /home/username/Wikitongues/Indexing-Project/wikitongues-language-indexing.cfg for linux (path might work for macs as well, not sure though).

Loading the config has been abstracted into its own package to keep the language-indexing.py file cleaner.
