### PR TITLE
Add airtable API parameters page_size and max_records

### DIFF
--- a/test/test_airtable_language_data_store.py
+++ b/test/test_airtable_language_data_store.py
@@ -29,7 +29,7 @@ NULL_ID = 'zzz'
 
 
 class MockAirtableHttpClient(IAirtableHttpClient):
-    def list_records(self):
+    def list_records(self, page_size, max_records):
         return MockResponse()
 
     def get_record(self, id):

--- a/wikitongues/wikitongues/data_store/airtable/airtable_http_client.py
+++ b/wikitongues/wikitongues/data_store/airtable/airtable_http_client.py
@@ -75,14 +75,14 @@ class AirtableHttpClient(IAirtableHttpClient):
 
         self._id_column = table_info.id_column
 
-    def list_records(self, page_size=None, offset=None, max_records=100):
+    def list_records(self, page_size=100, offset=None, max_records=None):
         """
         List records
 
         Args:
-            page_size (int, optional): Page size. Defaults to None.
+            page_size (int, optional): Page size. Defaults to 100.
             offset (str, optional): Offset for pagination. Defaults to None.
-            max_records (int, optional): Max records. Defaults to 100.
+            max_records (int, optional): Max records. Defaults to None.
 
         Returns:
             Response: Response from Airtable API

--- a/wikitongues/wikitongues/data_store/airtable/airtable_http_client.py
+++ b/wikitongues/wikitongues/data_store/airtable/airtable_http_client.py
@@ -87,7 +87,7 @@ class AirtableHttpClient(IAirtableHttpClient):
         Returns:
             Response: Response from Airtable API
         """
-        
+
         params = [
             f'maxRecords={max_records}'
         ]

--- a/wikitongues/wikitongues/data_store/airtable/airtable_http_client.py
+++ b/wikitongues/wikitongues/data_store/airtable/airtable_http_client.py
@@ -12,14 +12,14 @@ class IAirtableHttpClient(ABC):
     """
 
     @abstractmethod
-    def list_records(self, page_size=None, offset=None, max_records=100):
+    def list_records(self, page_size=100, offset=None, max_records=None):
         """
         List records
 
         Args:
-            page_size (int, optional): Page size. Defaults to None.
+            page_size (int, optional): Page size. Defaults to 100.
             offset (str, optional): Offset for pagination. Defaults to None.
-            max_records (int, optional): Max records. Defaults to 100.
+            max_records (int, optional): Max records. Defaults to None.
         """
         pass
 
@@ -87,7 +87,7 @@ class AirtableHttpClient(IAirtableHttpClient):
         Returns:
             Response: Response from Airtable API
         """
-
+        
         params = [
             f'maxRecords={max_records}'
         ]

--- a/wikitongues/wikitongues/data_store/airtable/airtable_language_data_store.py
+++ b/wikitongues/wikitongues/data_store/airtable/airtable_language_data_store.py
@@ -93,7 +93,7 @@ class AirtableLanguageDataStore(LanguageDataStore):
 
         result = ErrorResponse()
 
-        response = self._client.list_records(page_size, max_records)
+        response = self._client.list_records(page_size=page_size, max_records=max_records)
 
         if response.status_code != 200:
             result.add_message(

--- a/wikitongues/wikitongues/data_store/airtable/airtable_language_data_store.py
+++ b/wikitongues/wikitongues/data_store/airtable/airtable_language_data_store.py
@@ -93,7 +93,8 @@ class AirtableLanguageDataStore(LanguageDataStore):
 
         result = ErrorResponse()
 
-        response = self._client.list_records(page_size=page_size, max_records=max_records)
+        response = self._client.list_records(page_size=page_size, \
+            max_records=max_records)
 
         if response.status_code != 200:
             result.add_message(

--- a/wikitongues/wikitongues/data_store/airtable/airtable_language_data_store.py
+++ b/wikitongues/wikitongues/data_store/airtable/airtable_language_data_store.py
@@ -93,8 +93,8 @@ class AirtableLanguageDataStore(LanguageDataStore):
 
         result = ErrorResponse()
 
-        response = self._client.list_records(page_size=page_size, \
-            max_records=max_records)
+        response = self._client.list_records(
+            page_size=page_size, max_records=max_records)
 
         if response.status_code != 200:
             result.add_message(

--- a/wikitongues/wikitongues/data_store/airtable/airtable_language_data_store.py
+++ b/wikitongues/wikitongues/data_store/airtable/airtable_language_data_store.py
@@ -83,7 +83,7 @@ class AirtableLanguageDataStore(LanguageDataStore):
         result.data = languages
         return result
 
-    def list_languages(self):
+    def list_languages(self, page_size, max_records):
         """
         Retrieves list of language objects
 
@@ -93,7 +93,7 @@ class AirtableLanguageDataStore(LanguageDataStore):
 
         result = ErrorResponse()
 
-        response = self._client.list_records()
+        response = self._client.list_records(page_size, max_records)
 
         if response.status_code != 200:
             result.add_message(

--- a/wikitongues/wikitongues/data_store/airtable/airtable_language_data_store.py
+++ b/wikitongues/wikitongues/data_store/airtable/airtable_language_data_store.py
@@ -83,7 +83,7 @@ class AirtableLanguageDataStore(LanguageDataStore):
         result.data = languages
         return result
 
-    def list_languages(self, page_size, max_records):
+    def list_languages(self, page_size=100, max_records=None):
         """
         Retrieves list of language objects
 

--- a/wikitongues/wikitongues/data_store/airtable/airtable_table_info.py
+++ b/wikitongues/wikitongues/data_store/airtable/airtable_table_info.py
@@ -10,8 +10,8 @@ class AirtableTableInfo:
         Args:
             name (str): Table name
             id_column (str): Name of identifier column
-            page_size (int): Number of records returned in each request
-            max_records (int): Max records to retrieve
+            page_size (int, optional): Number of records returned in each request
+            max_records (int, optional): Max records to retrieve
         """
 
         self.name = name

--- a/wikitongues/wikitongues/data_store/airtable/airtable_table_info.py
+++ b/wikitongues/wikitongues/data_store/airtable/airtable_table_info.py
@@ -3,14 +3,18 @@ class AirtableTableInfo:
     Information for retrieving data from a Table on Airtable
     """
 
-    def __init__(self, name, id_column):
+    def __init__(self, name, id_column, page_size=100, max_records=100):
         """
         Construct AirtableTableInfo
 
         Args:
             name (str): Table name
             id_column (str): Name of identifier column
+            page_size (int): Number of records returned in each request
+            max_records (int): Max records to retrieve
         """
 
         self.name = name
         self.id_column = id_column
+        self.page_size = page_size
+        self.max_records = max_records

--- a/wikitongues/wikitongues/data_store/airtable/airtable_table_info.py
+++ b/wikitongues/wikitongues/data_store/airtable/airtable_table_info.py
@@ -10,7 +10,7 @@ class AirtableTableInfo:
         Args:
             name (str): Table name
             id_column (str): Name of identifier column
-            page_size (int, optional): Number of records returned in each request
+            page_size (int, optional): Number of records returned per request
             max_records (int, optional): Max records to retrieve
         """
 

--- a/wikitongues/wikitongues/language_indexing.py
+++ b/wikitongues/wikitongues/language_indexing.py
@@ -19,9 +19,11 @@ base_id = ''
 api_key = ''
 table_name = 'Languages'
 id_column = 'Identifier'
+page_size = 100
+max_records = None
 
 connection_info = AirtableConnectionInfo(base_id, api_key)
-table_info = AirtableTableInfo(table_name, id_column)
+table_info = AirtableTableInfo(table_name, id_column, page_size, max_records)
 
 # Get a LanguageDataStore instance
 # fake=True will give us a fake data store that returns a sample set of


### PR DESCRIPTION
Added parameters to AirtableTableInfo class. I noticed that the default parameters are switched in the AirtableHttpClient class? 

<img width="536" alt="Screen Shot 2021-05-18 at 4 36 16 PM" src="https://user-images.githubusercontent.com/44509349/118736335-2c1f8380-b7f7-11eb-933a-04a1215a65d1.png">
