### PR TITLE
Read airtable from config

### DIFF
--- a/wikitongues/wikitongues/config/indexing.cfg
+++ b/wikitongues/wikitongues/config/indexing.cfg
@@ -32,6 +32,8 @@ file_name : wikitongues-language-indexing.cfg
 # Uncomment below to override
  table_name : Languages
  id_column : Identifier
+ page_size : 100
+# max_records : 10
 # base_id : {your base id}
 # api_key : {your api key}
 # fake : true
@@ -39,6 +41,8 @@ file_name : wikitongues-language-indexing.cfg
 [airtable_items_table]
  table_name : External Resources
  id_column : Url
+ page_size : 100
+# max_records : 10
 # base_id : {your base id}
 # api_key : {your api key}
 # fake : true
@@ -49,3 +53,4 @@ base_id : {your base id}
 api_key : {your api key}
 # DO NOT MODIFY
 fake : false
+max_records

--- a/wikitongues/wikitongues/config/indexing.cfg
+++ b/wikitongues/wikitongues/config/indexing.cfg
@@ -26,27 +26,28 @@ wikipedia : WikipediaSpider
 fake : fake_spider
 
 [local_config_file]
-local config file : wikitongues-language-indexing.cfg
-
-[airtable_connection_info]
-base_id = {your base id}
-api_key = {your api key}
-fake = False  # defaults to False
-
-[airtable_table_info]
-name = Languages
-id_column = Identifier
+file_name : wikitongues-language-indexing.cfg
 
 [airtable_languages_table]
-name = Languages
-id_column = Identifier
-base_id = {your base id}  # optional
-api_key = {your api key}  # optional
-fake = False  # defaults to False
+# Uncomment below to override
+# table_name : Languages
+# id_column : Identifier
+# base_id : {your base id}
+# api_key : {your api key}
+# fake : true
 
 [airtable_items_table]
-name = External Resources
-id_column = Url
-base_id = {your base id}  # optional
-api_key = {your api key}  # optional
-fake = False  # defaults to False
+# table_name : External Resources
+# id_column : Url
+# base_id : {your base id}
+# api_key : {your api key}
+# fake : true
+
+[DEFAULT]
+# MODIFY
+base_id : {your base id}
+api_key : {your api key}
+# DO NOT MODIFY
+fake : false
+table_name : Languages
+id_column : Identifier

--- a/wikitongues/wikitongues/config/indexing.cfg
+++ b/wikitongues/wikitongues/config/indexing.cfg
@@ -30,15 +30,15 @@ file_name : wikitongues-language-indexing.cfg
 
 [airtable_languages_table]
 # Uncomment below to override
-# table_name : Languages
-# id_column : Identifier
+ table_name : Languages
+ id_column : Identifier
 # base_id : {your base id}
 # api_key : {your api key}
 # fake : true
 
 [airtable_items_table]
-# table_name : External Resources
-# id_column : Url
+ table_name : External Resources
+ id_column : Url
 # base_id : {your base id}
 # api_key : {your api key}
 # fake : true
@@ -49,5 +49,3 @@ base_id : {your base id}
 api_key : {your api key}
 # DO NOT MODIFY
 fake : false
-table_name : Languages
-id_column : Identifier

--- a/wikitongues/wikitongues/config/indexing.cfg
+++ b/wikitongues/wikitongues/config/indexing.cfg
@@ -27,3 +27,26 @@ fake : fake_spider
 
 [local_config_file]
 local config file : wikitongues-language-indexing.cfg
+
+[airtable_connection_info]
+base_id = {your base id}
+api_key = {your api key}
+fake = False  # defaults to False
+
+[airtable_table_info]
+name = Languages
+id_column = Identifier
+
+[airtable_languages_table]
+name = Languages
+id_column = Identifier
+base_id = {your base id}  # optional
+api_key = {your api key}  # optional
+fake = False  # defaults to False
+
+[airtable_items_table]
+name = External Resources
+id_column = Url
+base_id = {your base id}  # optional
+api_key = {your api key}  # optional
+fake = False  # defaults to False

--- a/wikitongues/wikitongues/config/load_configs.py
+++ b/wikitongues/wikitongues/config/load_configs.py
@@ -16,7 +16,6 @@ from wikitongues.wikitongues.data_store.airtable.offset_utility \
 
 def load_main_config():
 
-
     print("loading config file")
 
     default_config = configparser.ConfigParser()
@@ -55,8 +54,8 @@ def load_main_config():
         print("Using default configuration")
         return default_config
 
-def load_item_airtable_datastores(config):
 
+def load_item_airtable_datastores(config):
 
     config_item_table = config['airtable_items_table']
 
@@ -75,8 +74,8 @@ def load_item_airtable_datastores(config):
         config_item_table.getboolean('fake'))
     return item_datastore
 
-def load_languages_airtable_datastores(config):
 
+def load_languages_airtable_datastores(config):
 
     config_languages_table = config['airtable_languages_table']
     # Get a LanguageDataStore instance

--- a/wikitongues/wikitongues/config/load_configs.py
+++ b/wikitongues/wikitongues/config/load_configs.py
@@ -11,7 +11,7 @@ def load_configs():
     default_config = configparser.ConfigParser()
     current_dir = os.path.dirname(__file__)
     default_config.read_file(open(os.path.join(current_dir, "indexing.cfg")))
-    local_config_file = default_config.items("local_config_file")
+    local_config_file = default_config["local_config_file"]
 
     user_config = configparser.ConfigParser()
 
@@ -23,7 +23,7 @@ def load_configs():
         raise Exception("This program is intended only for Mac,"
                         + "Linux, or Windows machines.")
 
-    user_config_path = os.sep.join([env, local_config_file['local config file']])
+    user_config_path = os.sep.join([env, local_config_file['file_name']])
 
     try:
         user_config_file = open(user_config_path)

--- a/wikitongues/wikitongues/config/load_configs.py
+++ b/wikitongues/wikitongues/config/load_configs.py
@@ -3,11 +3,15 @@ from sys import platform
 import configparser
 import os
 
-from data_store.airtable.airtable_connection_info import AirtableConnectionInfo
-from data_store.airtable.airtable_item_data_store_factory import AirtableItemDataStoreFactory
-from data_store.airtable.airtable_language_data_store_factory import AirtableLanguageDataStoreFactory
+from data_store.airtable.airtable_connection_info \
+    import AirtableConnectionInfo
+from data_store.airtable.airtable_item_data_store_factory \
+    import AirtableItemDataStoreFactory
+from data_store.airtable.airtable_language_data_store_factory \
+    import AirtableLanguageDataStoreFactory
 from data_store.airtable.airtable_table_info import AirtableTableInfo
-from wikitongues.wikitongues.data_store.airtable.offset_utility import OffsetUtility
+from wikitongues.wikitongues.data_store.airtable.offset_utility \
+    import OffsetUtility
 
 def load_main_config():
 
@@ -75,10 +79,13 @@ def load_languages_airtable_datastores(config):
     #   languages and does not require Airtable credentials
     languages_datastore = AirtableLanguageDataStoreFactory.get_data_store(
         AirtableConnectionInfo(
-            config_languages_table['base_id'], config_languages_table['api_key']),
+            config_languages_table['base_id'],
+            config_languages_table['api_key']),
         AirtableTableInfo(
-            config_languages_table['table_name'], config_languages_table['id_column'],
-            config_languages_table['page_size'], OffsetUtility.read_offset(),
+            config_languages_table['table_name'],
+            config_languages_table['id_column'],
+            config_languages_table['page_size'],
+            OffsetUtility.read_offset(),
             config_languages_table['max_records']),
         config_languages_table.getboolean('fake'))
     return languages_datastore

--- a/wikitongues/wikitongues/config/load_configs.py
+++ b/wikitongues/wikitongues/config/load_configs.py
@@ -16,6 +16,7 @@ from wikitongues.wikitongues.data_store.airtable.offset_utility \
 
 def load_main_config():
 
+
     print("loading config file")
 
     default_config = configparser.ConfigParser()
@@ -56,6 +57,7 @@ def load_main_config():
 
 def load_item_airtable_datastores(config):
 
+
     config_item_table = config['airtable_items_table']
 
     # TODO check base_id and api_key are valid before creating the objects.
@@ -74,6 +76,7 @@ def load_item_airtable_datastores(config):
     return item_datastore
 
 def load_languages_airtable_datastores(config):
+
 
     config_languages_table = config['airtable_languages_table']
     # Get a LanguageDataStore instance

--- a/wikitongues/wikitongues/config/load_configs.py
+++ b/wikitongues/wikitongues/config/load_configs.py
@@ -23,7 +23,7 @@ def load_configs():
         raise Exception("This program is intended only for Mac,"
                         + "Linux, or Windows machines.")
 
-    user_config_path = os.sep.join([env, local_config_file[0][1]])
+    user_config_path = os.sep.join([env, local_config_file['local config file']])
 
     try:
         user_config_file = open(user_config_path)

--- a/wikitongues/wikitongues/config/load_configs.py
+++ b/wikitongues/wikitongues/config/load_configs.py
@@ -49,25 +49,32 @@ def load_main_config():
         print("Using default configuration")
         return default_config
 
-def load_airtable_datastores(config):
-    config_languages_table = config['airtable_languages_table']
+def load_item_airtable_datastores(config):
     config_item_table = config['airtable_items_table']
 
-    # Get a LanguageDataStore instance
-    # fake=True will give us a fake data store that returns a sample set of
-    #   languages and does not require Airtable credentials
+
     # TODO check base_id and api_key are valid before creating the objects.
 
-    languages_datastore = AirtableLanguageDataStoreFactory.get_data_store(
-        AirtableConnectionInfo(
-            config_languages_table['base_id'], config_languages_table['api_key']),
-        AirtableTableInfo(
-            config_languages_table['table_name'], config_languages_table['id_column']),
-        config_languages_table.getboolean('fake'))
+    # Get a ItemDataStore instance
+    # fake=True will give us a fake data store that returns a sample set of
+    #   languages and does not require Airtable credentials
     item_datastore = AirtableItemDataStoreFactory.get_data_store(
         AirtableConnectionInfo(
             config_item_table['base_id'], config_item_table['api_key']),
         AirtableTableInfo(
             config_item_table['table_name'], config_item_table['id_column']),
         config_item_table.getboolean('fake'))
-    return {"language_datastore": languages_datastore, "item_datastore": item_datastore}
+    return item_datastore
+
+def load_languages_airtable_datastores(config):
+    config_languages_table = config['airtable_languages_table']
+    # Get a LanguageDataStore instance
+    # fake=True will give us a fake data store that returns a sample set of
+    #   languages and does not require Airtable credentials
+    languages_datastore = AirtableLanguageDataStoreFactory.get_data_store(
+        AirtableConnectionInfo(
+            config_languages_table['base_id'], config_languages_table['api_key']),
+        AirtableTableInfo(
+            config_languages_table['table_name'], config_languages_table['id_column']),
+        config_languages_table.getboolean('fake'))
+    return languages_datastore

--- a/wikitongues/wikitongues/config/load_configs.py
+++ b/wikitongues/wikitongues/config/load_configs.py
@@ -13,6 +13,7 @@ from data_store.airtable.airtable_table_info import AirtableTableInfo
 from wikitongues.wikitongues.data_store.airtable.offset_utility \
     import OffsetUtility
 
+
 def load_main_config():
 
     print("loading config file")
@@ -54,8 +55,8 @@ def load_main_config():
         return default_config
 
 def load_item_airtable_datastores(config):
-    config_item_table = config['airtable_items_table']
 
+    config_item_table = config['airtable_items_table']
 
     # TODO check base_id and api_key are valid before creating the objects.
 
@@ -73,6 +74,7 @@ def load_item_airtable_datastores(config):
     return item_datastore
 
 def load_languages_airtable_datastores(config):
+
     config_languages_table = config['airtable_languages_table']
     # Get a LanguageDataStore instance
     # fake=True will give us a fake data store that returns a sample set of

--- a/wikitongues/wikitongues/config/load_configs.py
+++ b/wikitongues/wikitongues/config/load_configs.py
@@ -7,7 +7,7 @@ from data_store.airtable.airtable_connection_info import AirtableConnectionInfo
 from data_store.airtable.airtable_item_data_store_factory import AirtableItemDataStoreFactory
 from data_store.airtable.airtable_language_data_store_factory import AirtableLanguageDataStoreFactory
 from data_store.airtable.airtable_table_info import AirtableTableInfo
-
+from wikitongues.wikitongues.data_store.airtable.offset_utility import OffsetUtility
 
 def load_main_config():
 
@@ -62,7 +62,9 @@ def load_item_airtable_datastores(config):
         AirtableConnectionInfo(
             config_item_table['base_id'], config_item_table['api_key']),
         AirtableTableInfo(
-            config_item_table['table_name'], config_item_table['id_column']),
+            config_item_table['table_name'], config_item_table['id_column'],
+            config_item_table['page_size'], OffsetUtility.read_offset(),
+            config_item_table['max_records']),
         config_item_table.getboolean('fake'))
     return item_datastore
 
@@ -75,6 +77,8 @@ def load_languages_airtable_datastores(config):
         AirtableConnectionInfo(
             config_languages_table['base_id'], config_languages_table['api_key']),
         AirtableTableInfo(
-            config_languages_table['table_name'], config_languages_table['id_column']),
+            config_languages_table['table_name'], config_languages_table['id_column'],
+            config_languages_table['page_size'], OffsetUtility.read_offset(),
+            config_languages_table['max_records']),
         config_languages_table.getboolean('fake'))
     return languages_datastore

--- a/wikitongues/wikitongues/config/load_configs.py
+++ b/wikitongues/wikitongues/config/load_configs.py
@@ -3,8 +3,13 @@ from sys import platform
 import configparser
 import os
 
+from data_store.airtable.airtable_connection_info import AirtableConnectionInfo
+from data_store.airtable.airtable_item_data_store_factory import AirtableItemDataStoreFactory
+from data_store.airtable.airtable_language_data_store_factory import AirtableLanguageDataStoreFactory
+from data_store.airtable.airtable_table_info import AirtableTableInfo
 
-def load_configs():
+
+def load_main_config():
 
     print("loading config file")
 
@@ -43,3 +48,26 @@ def load_configs():
         # nothing overridden. return the default config settings
         print("Using default configuration")
         return default_config
+
+def load_airtable_datastores(config):
+    config_languages_table = config['airtable_languages_table']
+    config_item_table = config['airtable_items_table']
+
+    # Get a LanguageDataStore instance
+    # fake=True will give us a fake data store that returns a sample set of
+    #   languages and does not require Airtable credentials
+    # TODO check base_id and api_key are valid before creating the objects.
+
+    languages_datastore = AirtableLanguageDataStoreFactory.get_data_store(
+        AirtableConnectionInfo(
+            config_languages_table['base_id'], config_languages_table['api_key']),
+        AirtableTableInfo(
+            config_languages_table['table_name'], config_languages_table['id_column']),
+        config_languages_table.getboolean('fake'))
+    item_datastore = AirtableItemDataStoreFactory.get_data_store(
+        AirtableConnectionInfo(
+            config_item_table['base_id'], config_item_table['api_key']),
+        AirtableTableInfo(
+            config_item_table['table_name'], config_item_table['id_column']),
+        config_item_table.getboolean('fake'))
+    return {"language_datastore": languages_datastore, "item_datastore": item_datastore}

--- a/wikitongues/wikitongues/language_indexing.py
+++ b/wikitongues/wikitongues/language_indexing.py
@@ -8,10 +8,7 @@ import os
 import importlib
 from config.load_configs import load_main_config, load_item_airtable_datastores, load_languages_airtable_datastores
 from spiders.wikipedia_spider import WikipediaSpiderInput  # noqa: E501
-from data_store.airtable.airtable_language_data_store_factory import AirtableLanguageDataStoreFactory  # noqa: E501
-from data_store.airtable.airtable_item_data_store_factory import AirtableItemDataStoreFactory  # noqa: E501
-from data_store.airtable.airtable_connection_info import AirtableConnectionInfo
-from data_store.airtable.airtable_table_info import AirtableTableInfo
+
 
 # load config for running the spiders
 config = load_main_config()

--- a/wikitongues/wikitongues/language_indexing.py
+++ b/wikitongues/wikitongues/language_indexing.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 # Entry point for the program, invoked from the console
+import re
 import sys
 
 from scrapy.crawler import CrawlerProcess
@@ -14,26 +15,48 @@ from data_store.airtable.airtable_connection_info import AirtableConnectionInfo
 from data_store.airtable.airtable_table_info import AirtableTableInfo
 
 # Info required to connect to Airtable
+config = load_configs()
 # TODO read from config file
+config_connection_info = config.items('airtable_connection_info')
+config_table_info = config.items('airtable_table_info')
+config_languages_table_items = config.items('airtable_languages_table')
+config_item_table_items = config.items('airtable_items_table')
 base_id = ''
 api_key = ''
-table_name = 'Languages'
-id_column = 'Identifier'
+connection_info = ''
+languages_table_items = ''
+items_table_items = ''
 
-connection_info = AirtableConnectionInfo(base_id, api_key)
-table_info = AirtableTableInfo(table_name, id_column)
+if config_connection_info.getboolean('fake'):
+    connection_info = AirtableConnectionInfo('base_id, api_key')
+else:
+    connection_info = AirtableConnectionInfo(config_connection_info['base_id'], config_connection_info['api_key'])
+    # table_info = AirtableTableInfo(config_connection_info['name'], config_connection_info['id_column'])
 
 # Get a LanguageDataStore instance
 # fake=True will give us a fake data store that returns a sample set of
 #   languages and does not require Airtable credentials
-language_data_store = AirtableLanguageDataStoreFactory.get_data_store(
-    connection_info, table_info, fake=True)
+m = re.search('[{}<>]', config_languages_table_items['base_id'])
+languages_table_info = AirtableTableInfo(
+    config_table_info['name'], config_table_info['id_column'])
+items_table_info = AirtableTableInfo(
+    config_table_info['name'], config_table_info['id_column'])
+languages_data_store = AirtableLanguageDataStoreFactory.get_data_store(
+    connection_info,
+    languages_table_info,
+    config_languages_table_items.getboolean('fake'))
+item_data_store = AirtableItemDataStoreFactory.get_data_store(
+    connection_info,
+    items_table_info,
+    config_item_table_items.getboolean('fake'))
+
+# if len(config_languages_table_items['base_id']) > 0 and len(m) is 0:
+#    language_data_store = AirtableLanguageDataStoreFactory.get_data_store(
+#    connection_info, table_info, fake=True)
 
 # Get an ItemDataStore instance
 # fake=True will give us a fake data store that does not require Airtable
 #   credentials
-item_data_store = AirtableItemDataStoreFactory.get_data_store(
-    connection_info, table_info, fake=True)
 
 # Configure a CrawlerProcess
 process = CrawlerProcess(
@@ -64,11 +87,10 @@ def process_site(site_tuple):
 
             spider_input = WikipediaSpiderInput(iso_codes)
 
-            process.crawl(spider_class, spider_input, language_data_store)
+            process.crawl(spider_class, spider_input, languages_data_store)
             process.start()
 
 
-config = load_configs()
 sites = config.items('sites')
 
 start_all_crawls = input('Do you wish to crawl all spiders? (Y/N) ')

--- a/wikitongues/wikitongues/language_indexing.py
+++ b/wikitongues/wikitongues/language_indexing.py
@@ -6,7 +6,8 @@ import sys
 from scrapy.crawler import CrawlerProcess
 import os
 import importlib
-from config.load_configs import load_main_config, load_item_airtable_datastores, load_languages_airtable_datastores
+from config.load_configs import load_main_config, \
+    load_item_airtable_datastores, load_languages_airtable_datastores
 from spiders.wikipedia_spider import WikipediaSpiderInput  # noqa: E501
 
 

--- a/wikitongues/wikitongues/language_indexing.py
+++ b/wikitongues/wikitongues/language_indexing.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 # Entry point for the program, invoked from the console
-import re
 import sys
 
 from scrapy.crawler import CrawlerProcess
@@ -17,42 +16,27 @@ from data_store.airtable.airtable_table_info import AirtableTableInfo
 # Info required to connect to Airtable
 config = load_configs()
 # TODO read from config file
-config_connection_info = config.items('airtable_connection_info')
-config_table_info = config.items('airtable_table_info')
-config_languages_table_items = config.items('airtable_languages_table')
-config_item_table_items = config.items('airtable_items_table')
-base_id = ''
-api_key = ''
-connection_info = ''
-languages_table_items = ''
-items_table_items = ''
-
-if config_connection_info.getboolean('fake'):
-    connection_info = AirtableConnectionInfo('base_id, api_key')
-else:
-    connection_info = AirtableConnectionInfo(config_connection_info['base_id'], config_connection_info['api_key'])
-    # table_info = AirtableTableInfo(config_connection_info['name'], config_connection_info['id_column'])
+config_languages_table = config['airtable_languages_table']
+config_item_table = config['airtable_items_table']
 
 # Get a LanguageDataStore instance
 # fake=True will give us a fake data store that returns a sample set of
 #   languages and does not require Airtable credentials
-m = re.search('[{}<>]', config_languages_table_items['base_id'])
-languages_table_info = AirtableTableInfo(
-    config_table_info['name'], config_table_info['id_column'])
-items_table_info = AirtableTableInfo(
-    config_table_info['name'], config_table_info['id_column'])
-languages_data_store = AirtableLanguageDataStoreFactory.get_data_store(
-    connection_info,
-    languages_table_info,
-    config_languages_table_items.getboolean('fake'))
-item_data_store = AirtableItemDataStoreFactory.get_data_store(
-    connection_info,
-    items_table_info,
-    config_item_table_items.getboolean('fake'))
+# TODO check base_id and api_key are valid before creating the objects.
 
-# if len(config_languages_table_items['base_id']) > 0 and len(m) is 0:
-#    language_data_store = AirtableLanguageDataStoreFactory.get_data_store(
-#    connection_info, table_info, fake=True)
+languages_data_store = AirtableLanguageDataStoreFactory.get_data_store(
+    AirtableConnectionInfo(
+        config_languages_table['base_id'], config_languages_table['api_key']),
+    AirtableTableInfo(
+        config_languages_table['table_name'], config_languages_table['id_column']),
+    config_languages_table.getboolean('fake'))
+item_data_store = AirtableItemDataStoreFactory.get_data_store(
+    AirtableConnectionInfo(
+        config_item_table['base_id'], config_item_table['api_key']),
+    AirtableTableInfo(
+        config_item_table['table_name'], config_item_table['id_column']),
+    config_item_table.getboolean('fake'))
+
 
 # Get an ItemDataStore instance
 # fake=True will give us a fake data store that does not require Airtable

--- a/wikitongues/wikitongues/language_indexing.py
+++ b/wikitongues/wikitongues/language_indexing.py
@@ -13,9 +13,9 @@ from data_store.airtable.airtable_item_data_store_factory import AirtableItemDat
 from data_store.airtable.airtable_connection_info import AirtableConnectionInfo
 from data_store.airtable.airtable_table_info import AirtableTableInfo
 
-# Info required to connect to Airtable
+# load config for running the spiders
 config = load_configs()
-# TODO read from config file
+# Info required to connect to Airtable
 config_languages_table = config['airtable_languages_table']
 config_item_table = config['airtable_items_table']
 

--- a/wikitongues/wikitongues/language_indexing.py
+++ b/wikitongues/wikitongues/language_indexing.py
@@ -6,7 +6,7 @@ import sys
 from scrapy.crawler import CrawlerProcess
 import os
 import importlib
-from config.load_configs import load_main_config, load_airtable_datastores
+from config.load_configs import load_main_config, load_item_airtable_datastores, load_languages_airtable_datastores
 from spiders.wikipedia_spider import WikipediaSpiderInput  # noqa: E501
 from data_store.airtable.airtable_language_data_store_factory import AirtableLanguageDataStoreFactory  # noqa: E501
 from data_store.airtable.airtable_item_data_store_factory import AirtableItemDataStoreFactory  # noqa: E501
@@ -16,11 +16,8 @@ from data_store.airtable.airtable_table_info import AirtableTableInfo
 # load config for running the spiders
 config = load_main_config()
 # Info required to connect to Airtable
-datastores = load_airtable_datastores(config)
-
-# Get an ItemDataStore instance
-# fake=True will give us a fake data store that does not require Airtable
-#   credentials
+item_datastore = load_item_airtable_datastores(config)
+languages_datastore = load_languages_airtable_datastores(config)
 
 # Configure a CrawlerProcess
 process = CrawlerProcess(
@@ -30,7 +27,7 @@ process = CrawlerProcess(
                 "format": "jl"
             }
         },
-        'ITEM_DATA_STORE': datastores['item_datastore'],
+        'ITEM_DATA_STORE': item_datastore,
         'ITEM_PIPELINES': {
             'pipelines.WikitonguesPipeline': 300
         }
@@ -51,7 +48,7 @@ def process_site(site_tuple):
 
             spider_input = WikipediaSpiderInput(iso_codes)
 
-            process.crawl(spider_class, spider_input, datastores['languages_datastore'])
+            process.crawl(spider_class, spider_input, languages_datastore)
             process.start()
 
 


### PR DESCRIPTION
Added config details for the airtable datastore in the load_configs.py

the config varies slightly from the issue this is linked to. Instead of an Airtable_connection_info section in the config file, I added a DEFAULT section which has the same data plus a couple of other details. DEFAULT allows easy overriding if desired and removes the need to define default values in the custom sections themselves.

Additionally, I tried to set it so that static config values are specifically called instead of tuple values which work better for the dynamic config settings.