### PR TITLE
fix the read include and exclude languages

### DIFF
--- a/wikitongues/wikitongues/config/load_configs.py
+++ b/wikitongues/wikitongues/config/load_configs.py
@@ -97,12 +97,12 @@ def load_languages_airtable_datastores(config):
 def read_include_languages(config):
 
     if len(config.items("include_languages")) > 0:
-        return config['include_languages'].split(",")
+        return config['include_languages']['include_languages'].split(",")
     return None
 
 
 def read_exclude_languages(config):
 
     if len(config.items("exclude_languages")) > 0:
-        return config['exclude_languages'].split(",")
+        return config['exclude_languages']['exclude_languages'].split(",")
     return None

--- a/wikitongues/wikitongues/language_indexing.py
+++ b/wikitongues/wikitongues/language_indexing.py
@@ -10,6 +10,7 @@ from config.load_configs import load_main_config, \
     load_item_airtable_datastores, load_languages_airtable_datastores, \
     read_exclude_languages, read_include_languages
 from spiders.wikipedia_spider import WikipediaSpiderInput
+from data_store.airtable.offset_utility import OffsetUtility
 
 # load config for running the spiders
 config = load_main_config()
@@ -50,8 +51,7 @@ def process_site(site_tuple):
                                                 read_exclude_languages(config),
                                                 config_languages_table
                                                 ['page_size'],
-                                                config_languages_table
-                                                ['offset'],
+                                                OffsetUtility.read_offset(),
                                                 config_languages_table
                                                 ['max_records']
                                                 )


### PR DESCRIPTION
Fixed the read_include_languages function, read_exclude_languages function, and the offset issue.
You need something like 

[include_languages]
include_languages : sah,xho

[exclude_languages]
exclude_languages : eng,spa

inside your user config for it to work.