### PR TITLE
Issue 26 fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         '': 'wikitongues/wikitongues'
     },
     entry_points={
-        'console_scripts': ['language-indexing=language_indexing']
+        'console_scripts': ['language-indexing=language_indexing:main']
     },
     install_requires=[
         'Scrapy'

--- a/wikitongues/wikitongues/config/load_configs.py
+++ b/wikitongues/wikitongues/config/load_configs.py
@@ -97,12 +97,12 @@ def load_languages_airtable_datastores(config):
 def read_include_languages(config):
 
     if len(config.items("include_languages")) > 0:
-        return config['include_languages'].split(",")
+        return config['include_languages']['include_languages'].split(",")
     return None
 
 
 def read_exclude_languages(config):
 
     if len(config.items("exclude_languages")) > 0:
-        return config['exclude_languages'].split(",")
+        return config['exclude_languages']['exclude_languages'].split(",")
     return None

--- a/wikitongues/wikitongues/language_indexing.py
+++ b/wikitongues/wikitongues/language_indexing.py
@@ -2,6 +2,7 @@
 
 # Entry point for the program, invoked from the console
 import sys
+import types
 
 from scrapy.crawler import CrawlerProcess
 import os
@@ -11,31 +12,57 @@ from config.load_configs import load_main_config, \
     read_exclude_languages, read_include_languages
 from spiders.wikipedia_spider import WikipediaSpiderInput
 
-# load config for running the spiders
-config = load_main_config()
-# Info required to connect to Airtable
-item_datastore = load_item_airtable_datastores(config)
-languages_datastore = load_languages_airtable_datastores(config)
-# load languages table
-config_languages_table = config['airtable_languages_table']
 
-# Configure a CrawlerProcess
-process = CrawlerProcess(
-    settings={
-        "FEEDS": {
-            "items.jl": {
-                "format": "jl"
+def main():
+
+    # load config for running the spiders
+    configs = types.SimpleNamespace()
+    configs.main_config = load_main_config()
+    # Info required to connect to Airtable
+    configs.item_datastore = load_item_airtable_datastores(configs.main_config)
+    configs.languages_datastore = load_languages_airtable_datastores(configs.main_config)
+    # load languages table
+    configs.config_languages_table = configs.main_config['airtable_languages_table']
+
+    # Configure a CrawlerProcess
+    configs.process = CrawlerProcess(
+        settings={
+            "FEEDS": {
+                "items.jl": {
+                    "format": "jl"
+                }
+            },
+            'ITEM_DATA_STORE': configs.item_datastore,
+            'ITEM_PIPELINES': {
+                'pipelines.WikitonguesPipeline': 300
             }
-        },
-        'ITEM_DATA_STORE': item_datastore,
-        'ITEM_PIPELINES': {
-            'pipelines.WikitonguesPipeline': 300
         }
-    }
-)
+    )
+
+    sites = configs.main_config.items('sites')
+
+    start_all_crawls = input('Do you wish to crawl all spiders? (Y/N) ')
+
+    if start_all_crawls.lower() == 'n':
+        site_to_crawl = input('Which site would you like to crawl? ')
+        for site in sites:
+            if site_to_crawl == site[0]:
+                process_site(site, configs)
+                break
+        print('Invalid input: could not find a site that matched your input')
+        sys.exit(1)
+
+    elif start_all_crawls.lower() == 'y':
+        for site in sites:
+            process_site(site, configs)
+            print(site[1])
+
+    else:
+        print('invalid input')
+        sys.exit(1)
 
 
-def process_site(site_tuple):
+def process_site(site_tuple, configs):
 
     current_dir = os.path.dirname(__file__)
     spiders_dir_tree = os.listdir(os.path.join(current_dir, 'spiders'))
@@ -44,40 +71,20 @@ def process_site(site_tuple):
         if t.__contains__(site_tuple[0]):
             spider_class = getattr(
                 importlib.import_module(
-                    'spiders.' + t[:-3]), config['spiders'][site_tuple[0]])
+                    'spiders.' + t[:-3]), configs.main_config['spiders'][site_tuple[0]])
 
-            spider_input = WikipediaSpiderInput(read_include_languages(config),
-                                                read_exclude_languages(config),
-                                                config_languages_table
+            spider_input = WikipediaSpiderInput(read_include_languages(configs.main_config),
+                                                read_exclude_languages(configs.main_config),
+                                                configs.config_languages_table
                                                 ['page_size'],
-                                                config_languages_table
+                                                configs.config_languages_table
                                                 ['offset'],
-                                                config_languages_table
+                                                configs.config_languages_table
                                                 ['max_records']
                                                 )
 
-            process.crawl(spider_class, spider_input, languages_datastore)
-            process.start()
+            configs.process.crawl(spider_class, spider_input, configs.languages_datastore)
+            configs.process.start()
 
 
-sites = config.items('sites')
 
-start_all_crawls = input('Do you wish to crawl all spiders? (Y/N) ')
-
-if start_all_crawls.lower() == 'n':
-    site_to_crawl = input('Which site would you like to crawl? ')
-    for site in sites:
-        if site_to_crawl == site[0]:
-            process_site(site)
-            break
-    print('Invalid input: could not find a site that matched your input')
-    sys.exit(1)
-
-elif start_all_crawls.lower() == 'y':
-    for site in sites:
-        process_site(site)
-        print(site[1])
-
-else:
-    print('invalid input')
-    sys.exit(1)

--- a/wikitongues/wikitongues/language_indexing.py
+++ b/wikitongues/wikitongues/language_indexing.py
@@ -11,7 +11,7 @@ from config.load_configs import load_main_config, \
     load_item_airtable_datastores, load_languages_airtable_datastores, \
     read_exclude_languages, read_include_languages
 from spiders.wikipedia_spider import WikipediaSpiderInput
-
+from data_store.airtable.offset_utility import OffsetUtility
 
 def main():
 
@@ -77,8 +77,7 @@ def process_site(site_tuple, configs):
                                                 read_exclude_languages(configs.main_config),
                                                 configs.config_languages_table
                                                 ['page_size'],
-                                                configs.config_languages_table
-                                                ['offset'],
+                                                OffsetUtility.read_offset(),
                                                 configs.config_languages_table
                                                 ['max_records']
                                                 )


### PR DESCRIPTION
This is to address the issue identified [here](https://github.com/wikitongues/Language-Indexing/issues/26). In Setuptools, you can use console_scripts to register functions as entrypoints for a python application (see [here ](https://setuptools.readthedocs.io/en/latest/userguide/entry_point.html)at setuptools site, and [here ](https://python-packaging.readthedocs.io/en/latest/command-line-scripts.html#:~:text=Setuptools%20allows%20modules%20to%20register%20entrypoints%20which%20other,to%20be%20directly%20registered%20as%20command-line%20accessible%20tools.)at python-packaging.readthedocs.io for more details).
Right now, we are registering a script as an entrypoint. It still appears to work, and it's not clear whether there are any functional issues other than errors shown when running the language-indexing command. 
In order to avoid these errors, the language-indexing file is now structured with functions instead of as a script. Most of the logic in language_indexing is wrapped up in a main() function. 
The setup.py now registers the main method in the language-indexing file.

Additionally, I decided to create a configs object using the builtin Simplenamespace type that basically allows you to create a variable and treat it like a JavaScript object, where you can dynamically add attributes to an object. I thought it might keep all of the configs in a nice neat little variable. 

As always, feedback on any design decisions here is welcome.

NOTE:
At first even after making this change, running the language-indexing command still threw the "TypeError: 'module' object is not callable" error. After some research, it appears that somehow there is a conflict between the pip in the virtual env and the global pip. [This ](https://stackoverflow.com/questions/58386953/pip3-typeerror-module-object-is-not-callable-after-update)stackoverflow page and [this ](https://github.com/pypa/pip/issues/7205)github issue had suggested solutions to resolve which worked for me. I had to uninstall the virtual pip, reinstall it, and then upgrade it. I used the below commands within the venv of the language-indexing project:
python -m pip uninstall pip
python -m ensurepip
python -m pip install --upgrade pip

If you encounter this issue, give this solution a try. The error was permanently resolved after doing this once as long as I used the new version of the file. The workaround didn't work with the file structured as a script (the current main branch version of it).

If you run this on your local git repo, you will need to reinstall the setup.py. I found it simple enough to delete the virtual environment and recreate it, but you might not want to go through the hassle.  

